### PR TITLE
Resonators now have their replication mechanic

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -114,3 +114,10 @@
 	. = ..()
 	transform = matrix()*1.5
 	animate(src, transform = matrix()*0.1, alpha = 50, time = 4)
+
+/obj/effect/resonance/proc/replicate(turf/M, creator, timetoburst)
+	for(var/turf/closed/T in orange(1, M))
+		if(istype(T, M))
+			var/turf/closed/mineral/T2 = T
+			if(T2.mineralType) // so we don't end up in the ultimate chain reaction
+				new /obj/effect/resonance(T, creator, timetoburst)


### PR DESCRIPTION
When a resonance field detonates on an ore node that is adjacent to ore nodes of the same kind, the field will create duplicates that will detonate those nodes as well.