### PR TITLE
Resonators can now duplicate on entire mineral veins 

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -114,3 +114,10 @@
 	. = ..()
 	transform = matrix()*1.5
 	animate(src, transform = matrix()*0.1, alpha = 50, time = 4)
+
+/obj/effect/resonance/proc/replicate(turf/M, creator, timetoburst)
+	for(var/turf/closed/T in orange(1, M))
+		if(istype(T, M))
+			var/turf/closed/mineral/T2 = T
+			if(T2.mineralType) // so we don't end up in the ultimate chain reaction
+				new /obj/effect/resonance(T, creator, timetoburst)


### PR DESCRIPTION
### Intent of your Pull Request
Resonators (upgraded or base) will now create duplicate fields on ore nodes of the same type, meaning you too can mine entire veins of minerals for the price of your mining voucher! 


#### Changelog

:cl:  
rscadd: Resonators can now create duplicate resonance fields on adjacent ore nodes of the same type.
tweak: Due to the subpar performance resonators have had, Centcomm has decided to equip shaft miners with a version that will duplicate ore nodes adjacent to the detonated ore node. 

/:cl:
